### PR TITLE
Pre-bitnami template version locks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,8 +60,18 @@ jobs:
         node_image: kindest/node:v1.21.10
       if: steps.list-changed.outputs.changed == 'true'
 
+    - name: Create repo secret
+      run: |
+        kubectl create secret docker-registry soniclabs \
+          --namespace default \
+          --docker-server=ghcr.io \
+          --docker-username=${{ github.actor }} \
+          --docker-password=${{ secrets.GITHUB_TOKEN }} \
+          --docker-email=${{ github.actor }}@users.noreply.github.com
+      if: steps.list-changed.outputs.changed == 'true'
+
     - name: Run chart-testing (install)
       run: |
         ct install \
-        --target-branch ${{ github.event.repository.default_branch }}
+        --target-branch ${{ github.event.repository.default_branch }}  --namespace default
       if: steps.list-changed.outputs.changed == 'true'

--- a/charts/configmanager/Chart.lock
+++ b/charts/configmanager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.11.1
-digest: sha256:c3a919e1c632728faf2d8842c95880b0f2482fdbafa23363e33dcda84e202d8f
-generated: "2023-09-14T09:32:59.411343+01:00"
+  version: 12.12.10
+digest: sha256:4db62ecf2a15647b9902b5b4267a12aed89733f98b071bbc3c4219f464bb8479
+generated: "2023-09-27T13:40:07.430218+01:00"

--- a/charts/configmanager/Chart.yaml
+++ b/charts/configmanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: configmanager
 appVersion: 0.1.1
 description: A generated Helm Chart for Soniclabs T&M configmanager
-version: 0.0.5
+version: 0.0.6
 type: application
 maintainers:
   - name: cdecatapult

--- a/charts/configmanager/ci/ct-values.yaml
+++ b/charts/configmanager/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+config:
+  type: ClusterIP

--- a/charts/configmanager/templates/_helpers.tpl
+++ b/charts/configmanager/templates/_helpers.tpl
@@ -89,3 +89,14 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "configmanager.image" -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "%s@%s" .repository .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/configmanager/templates/deployment.yaml
+++ b/charts/configmanager/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
       {{- include "configmanager.imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: {{ include "configmanager.fullname" . }}-init
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "configmanager.image" .Values.image }}
           command: ['sleep', '60']
       containers:
         - name: {{ include "configmanager.fullname" . }}-app
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "configmanager.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: {{ .Values.config.appPort }}

--- a/charts/configmanager/templates/deployment.yaml
+++ b/charts/configmanager/templates/deployment.yaml
@@ -8,14 +8,14 @@ spec:
   replicas: {{ .Values.config.replicaCount }}
   selector:
     matchLabels:
-      name: {{ include "configmanager.fullname" . }}-app
+      {{- include "configmanager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
-        name: {{ include "configmanager.fullname" . }}-app
+        {{- include "configmanager.labels" . | nindent 8 }}
     spec:
       {{- include "configmanager.imagePullSecrets" . | indent 6 }}
       initContainers:

--- a/charts/configmanager/templates/svc.yaml
+++ b/charts/configmanager/templates/svc.yaml
@@ -10,8 +10,9 @@ spec:
   ports:
     - port: {{ .Values.config.appPort }}
       targetPort: {{ .Values.config.appPort }}
+      {{- if or (eq .Values.config.type "NodePort") (eq .Values.config.type "LoadBalancer") }}
       nodePort: {{ .Values.config.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
-  selector:
-    name: {{ include "configmanager.fullname" . }}-app
+  selector: {{- include "configmanager.selectorLabels" . | nindent 4 }}

--- a/charts/configmanager/values.yaml
+++ b/charts/configmanager/values.yaml
@@ -28,7 +28,7 @@ config:
 image:
   repository: ghcr.io/cdecatapult/soniclabs-configmanager
   pullPolicy: Always
-  tag: latest
+  tag: sha256:ee67c1d87d9f0c9b4438cf6d10d025f9995200c36cdccb7544cb77bf99f225b3
   pullSecrets: ['soniclabs']
 
 autoscaling:

--- a/charts/deploymanager/Chart.lock
+++ b/charts/deploymanager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.5.7
-digest: sha256:1b88720b28cd097236ebb696fc76a6fccabe0fe46fa72050cfd56657b0d1c686
-generated: "2023-06-13T11:48:37.838701+01:00"
+  version: 12.12.10
+digest: sha256:4db62ecf2a15647b9902b5b4267a12aed89733f98b071bbc3c4219f464bb8479
+generated: "2023-09-27T13:39:51.206851+01:00"

--- a/charts/deploymanager/Chart.yaml
+++ b/charts/deploymanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: deploymanager
 appVersion: 0.1.1
 description: A generated Helm Chart for Soniclabs T&M deploymanager
-version: 0.0.7
+version: 0.0.8
 type: application
 maintainers:
   - name: cdecatapult

--- a/charts/deploymanager/ci/ct-values.yaml
+++ b/charts/deploymanager/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+config:
+  type: ClusterIP

--- a/charts/deploymanager/templates/_helpers.tpl
+++ b/charts/deploymanager/templates/_helpers.tpl
@@ -89,3 +89,14 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "deploymanager.image" -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "%s@%s" .repository .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/deploymanager/templates/deployment.yaml
+++ b/charts/deploymanager/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
       {{- include "deploymanager.imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: {{ include "deploymanager.fullname" . }}-init
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "deploymanager.image" .Values.image }}
           command: ['sleep', '60']
       containers:
         - name: {{ include "deploymanager.fullname" . }}-app
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "deploymanager.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: {{ .Values.config.appPort }}

--- a/charts/deploymanager/templates/deployment.yaml
+++ b/charts/deploymanager/templates/deployment.yaml
@@ -8,14 +8,14 @@ spec:
   replicas: {{ .Values.config.replicaCount }}
   selector:
     matchLabels:
-      name: {{ include "deploymanager.fullname" . }}-app
+      {{- include "deploymanager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
-        name: {{ include "deploymanager.fullname" . }}-app
+        {{- include "deploymanager.labels" . | nindent 8 }}
     spec:
       {{- include "deploymanager.imagePullSecrets" . | indent 6 }}
       initContainers:

--- a/charts/deploymanager/templates/svc.yaml
+++ b/charts/deploymanager/templates/svc.yaml
@@ -15,5 +15,4 @@ spec:
       {{- end }}
       protocol: TCP
       name: http
-  selector:
-    selector: {{- include "deploymanager.selectorLabels" . | nindent 4 }}
+  selector: {{- include "deploymanager.selectorLabels" . | nindent 4 }}

--- a/charts/deploymanager/templates/svc.yaml
+++ b/charts/deploymanager/templates/svc.yaml
@@ -10,8 +10,10 @@ spec:
   ports:
     - port: {{ .Values.config.appPort }}
       targetPort: {{ .Values.config.appPort }}
-#       nodePort: {{ .Values.config.nodePort }}
+      {{- if or (eq .Values.config.type "NodePort") (eq .Values.config.type "LoadBalancer") }}
+      nodePort: {{ .Values.config.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:
-    name: {{ include "deploymanager.fullname" . }}-app
+    selector: {{- include "deploymanager.selectorLabels" . | nindent 4 }}

--- a/charts/deploymanager/values.yaml
+++ b/charts/deploymanager/values.yaml
@@ -9,7 +9,7 @@ config:
   replicaCount: 1
   appPort: 8000
   type: LoadBalancer
-#   nodePort: 30311
+  nodePort: 30311
   debug: "True"
   logLevel: DEBUG
   guiHost: portal

--- a/charts/deploymanager/values.yaml
+++ b/charts/deploymanager/values.yaml
@@ -30,7 +30,7 @@ config:
 image:
   repository: ghcr.io/cdecatapult/soniclabs-deploymanager
   pullPolicy: Always
-  tag: latest
+  tag: sha256:ac366fc98860b8b257a660e28895f129b7d332ae43f02d8d2b0fc8713f27c1f4
   pullSecrets: ['soniclabs']
 
 autoscaling:

--- a/charts/deploymanager/values.yaml
+++ b/charts/deploymanager/values.yaml
@@ -30,7 +30,7 @@ config:
 image:
   repository: ghcr.io/cdecatapult/soniclabs-deploymanager
   pullPolicy: Always
-  tag: sha256:ac366fc98860b8b257a660e28895f129b7d332ae43f02d8d2b0fc8713f27c1f4
+  tag: sha256:853dc8715d72807ab91a763a78feef6eff29d2b2200dba56c5d2bbf2c5457cd9
   pullSecrets: ['soniclabs']
 
 autoscaling:

--- a/charts/resultsmanager/Chart.lock
+++ b/charts/resultsmanager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.5.7
-digest: sha256:1b88720b28cd097236ebb696fc76a6fccabe0fe46fa72050cfd56657b0d1c686
-generated: "2023-06-13T11:48:37.838701+01:00"
+  version: 12.12.10
+digest: sha256:4db62ecf2a15647b9902b5b4267a12aed89733f98b071bbc3c4219f464bb8479
+generated: "2023-09-27T13:39:31.895929+01:00"

--- a/charts/resultsmanager/Chart.yaml
+++ b/charts/resultsmanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: resultsmanager
 appVersion: 0.1.1
 description: A generated Helm Chart for Soniclabs T&M resultsmanager
-version: 0.0.4
+version: 0.0.5
 type: application
 maintainers:
   - name: cdecatapult

--- a/charts/resultsmanager/ci/ct-values.yaml
+++ b/charts/resultsmanager/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+config:
+  type: ClusterIP

--- a/charts/resultsmanager/templates/_helpers.tpl
+++ b/charts/resultsmanager/templates/_helpers.tpl
@@ -89,3 +89,14 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "resultsmanager.image" -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "%s@%s" .repository .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/resultsmanager/templates/deployment.yaml
+++ b/charts/resultsmanager/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
       {{- include "resultsmanager.imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: {{ include "resultsmanager.fullname" . }}-init
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "resultsmanager.image" .Values.image }}
           command: ['sleep', '60']
       containers:
         - name: {{ include "resultsmanager.fullname" . }}-app
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "resultsmanager.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: {{ .Values.config.appPort }}

--- a/charts/resultsmanager/templates/deployment.yaml
+++ b/charts/resultsmanager/templates/deployment.yaml
@@ -8,14 +8,14 @@ spec:
   replicas: {{ .Values.config.replicaCount }}
   selector:
     matchLabels:
-      name: {{ include "resultsmanager.fullname" . }}-app
+      {{- include "resultsmanager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
-        name: {{ include "resultsmanager.fullname" . }}-app
+        {{- include "resultsmanager.labels" . | nindent 8 }}
     spec:
       {{- include "resultsmanager.imagePullSecrets" . | indent 6 }}
       initContainers:

--- a/charts/resultsmanager/templates/svc.yaml
+++ b/charts/resultsmanager/templates/svc.yaml
@@ -10,8 +10,10 @@ spec:
   ports:
     - port: {{ .Values.config.appPort }}
       targetPort: {{ .Values.config.appPort }}
+      {{- if or (eq .Values.config.type "NodePort") (eq .Values.config.type "LoadBalancer") }}
       nodePort: {{ .Values.config.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:
-    name: {{ include "resultsmanager.fullname" . }}-app
+    {{- include "resultsmanager.selectorLabels" . | nindent 4 }}

--- a/charts/resultsmanager/values.yaml
+++ b/charts/resultsmanager/values.yaml
@@ -9,7 +9,7 @@ config:
   replicaCount: 1
   appPort: 8000
   type: LoadBalancer
-#   nodePort: 30332
+  nodePort: 30332
   debug: "True"
   logLevel: DEBUG
   guiHost: portal

--- a/charts/resultsmanager/values.yaml
+++ b/charts/resultsmanager/values.yaml
@@ -30,7 +30,7 @@ config:
 image:
   repository: ghcr.io/cdecatapult/soniclabs-resultsmanager
   pullPolicy: Always
-  tag: latest
+  tag: sha256:8b7229f2a63624b259f3982e926a5ba2dc2741532e41e094131b06f1e9f2280d
   pullSecrets: ['soniclabs']
 
 autoscaling:

--- a/charts/suitemanager/Chart.lock
+++ b/charts/suitemanager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.5.7
-digest: sha256:1b88720b28cd097236ebb696fc76a6fccabe0fe46fa72050cfd56657b0d1c686
-generated: "2023-06-13T11:48:37.838701+01:00"
+  version: 12.12.10
+digest: sha256:4db62ecf2a15647b9902b5b4267a12aed89733f98b071bbc3c4219f464bb8479
+generated: "2023-09-27T13:45:28.239398+01:00"

--- a/charts/suitemanager/Chart.yaml
+++ b/charts/suitemanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: suitemanager
 appVersion: 0.1.1
 description: A generated Helm Chart for Soniclabs T&M suitemanager
-version: 0.0.6
+version: 0.0.7
 type: application
 maintainers:
   - name: cdecatapult

--- a/charts/suitemanager/ci/ct-values.yaml
+++ b/charts/suitemanager/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+config:
+  type: ClusterIP

--- a/charts/suitemanager/templates/_helpers.tpl
+++ b/charts/suitemanager/templates/_helpers.tpl
@@ -89,3 +89,14 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "suitemanager.image" -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "%s@%s" .repository .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/suitemanager/templates/deployment.yaml
+++ b/charts/suitemanager/templates/deployment.yaml
@@ -8,14 +8,14 @@ spec:
   replicas: {{ .Values.config.replicaCount }}
   selector:
     matchLabels:
-      name: {{ include "suitemanager.fullname" . }}-app
+      {{- include "suitemanager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
-        name: {{ include "suitemanager.fullname" . }}-app
+        {{- include "suitemanager.labels" . | nindent 8 }}
     spec:
       {{- include "suitemanager.imagePullSecrets" . | indent 6 }}
       initContainers:

--- a/charts/suitemanager/templates/deployment.yaml
+++ b/charts/suitemanager/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
       {{- include "suitemanager.imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: {{ include "suitemanager.fullname" . }}-init
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "suitemanager.image" .Values.image }}
           command: ['sleep', '60']
       containers:
         - name: {{ include "suitemanager.fullname" . }}-app
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "suitemanager.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: {{ .Values.config.appPort }}

--- a/charts/suitemanager/templates/svc.yaml
+++ b/charts/suitemanager/templates/svc.yaml
@@ -10,8 +10,10 @@ spec:
   ports:
     - port: {{ .Values.config.appPort }}
       targetPort: {{ .Values.config.appPort }}
+      {{- if or (eq .Values.config.type "NodePort") (eq .Values.config.type "LoadBalancer") }}
       nodePort: {{ .Values.config.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:
-    name: {{ include "suitemanager.fullname" . }}-app
+    {{- include "suitemanager.selectorLabels" . | nindent 4 }}

--- a/charts/suitemanager/values.yaml
+++ b/charts/suitemanager/values.yaml
@@ -30,7 +30,7 @@ config:
 image:
   repository: ghcr.io/cdecatapult/soniclabs-suitemanager
   pullPolicy: Always
-  tag: latest
+  tag: sha256:b28bbaae9d67c977d2155ed9fe7503e5561d8380ca55ef6980b6735140be6897
   pullSecrets: ['soniclabs']
 
 autoscaling:

--- a/charts/testmanager/Chart.yaml
+++ b/charts/testmanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: testmanager
 appVersion: 0.1.1
 description: A generated Helm Chart for Soniclabs T&M testmanager
-version: 0.0.3
+version: 0.0.4
 type: application
 maintainers:
   - name: cdecatapult

--- a/charts/testmanager/ci/ct-values.yaml
+++ b/charts/testmanager/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+config:
+  type: ClusterIP

--- a/charts/testmanager/templates/_helpers.tpl
+++ b/charts/testmanager/templates/_helpers.tpl
@@ -89,3 +89,14 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "testmanager.image" -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "%s@%s" .repository .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/testmanager/templates/deployment.yaml
+++ b/charts/testmanager/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
       {{- include "testmanager.imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: {{ include "testmanager.fullname" . }}-init
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "testmanager.image" .Values.image }}
           command: ['sleep', '60']
       containers:
         - name: {{ include "testmanager.fullname" . }}-app
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ template "testmanager.image" .Values.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: {{ .Values.config.appPort }}

--- a/charts/testmanager/templates/deployment.yaml
+++ b/charts/testmanager/templates/deployment.yaml
@@ -8,14 +8,14 @@ spec:
   replicas: {{ .Values.config.replicaCount }}
   selector:
     matchLabels:
-      name: {{ include "testmanager.fullname" . }}-app
+      {{- include "testmanager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
-        name: {{ include "testmanager.fullname" . }}-app
+        {{- include "testmanager.labels" . | nindent 8 }}
     spec:
       {{- include "testmanager.imagePullSecrets" . | indent 6 }}
       initContainers:

--- a/charts/testmanager/templates/svc.yaml
+++ b/charts/testmanager/templates/svc.yaml
@@ -10,8 +10,10 @@ spec:
   ports:
     - port: {{ .Values.config.appPort }}
       targetPort: {{ .Values.config.appPort }}
+      {{- if or (eq .Values.config.type "NodePort") (eq .Values.config.type "LoadBalancer") }}
       nodePort: {{ .Values.config.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:
-    name: {{ include "testmanager.fullname" . }}-app
+    {{- include "testmanager.selectorLabels" . | nindent 4 }}

--- a/charts/testmanager/values.yaml
+++ b/charts/testmanager/values.yaml
@@ -30,7 +30,7 @@ config:
 image:
   repository: ghcr.io/cdecatapult/soniclabs-testmanager
   pullPolicy: Always
-  tag: latest
+  tag: sha256:244f8164e526e99a1c9e634679b24fbbd38577e528eb219e0362514bac951324
   pullSecrets: ['soniclabs']
 
 autoscaling:


### PR DESCRIPTION
Adds:
- Ability to use sha digests as well as tags for image versions.
- CI Testing defaults.

Fixes:
- Kind cluster correctly authenticates to image registry using pullSecrets.
- Uses correct selector labels.
- Uses correct labels.
- Doesn't add NodePort to service if serviceType is not LoadBalancer or NodePort.